### PR TITLE
Move and add transformation helpers

### DIFF
--- a/Section1-WeatherHolidaysPipeline/pipeline/extract.py
+++ b/Section1-WeatherHolidaysPipeline/pipeline/extract.py
@@ -47,24 +47,6 @@ def build_weather_api_url(
     return f"{BASE_ARCHIVE_API_URL}/archive?" + "&".join(params)
 
 
-def group_weather_info(weather_data: dict) -> list[dict]:
-    """
-        Convert a dict of lists into a list of dicts, one per index.
-
-        All keys in the input dict must map to lists of the same length.
-    """
-    grouped_data = []
-    number_of_elements = len(weather_data["time"])
-
-    for i in range(number_of_elements):
-        data = {}
-        for key, value in weather_data.items():
-            data[key] = value[i]
-        grouped_data.append(data)
-
-    return grouped_data
-
-
 def get_current_date(time_zone: str) -> datetime:
     return datetime.now(ZoneInfo(time_zone)).date()
 
@@ -80,17 +62,6 @@ def get_weather_data(url: str, data_type: Literal["hourly", "daily"] = "daily") 
     response = requests.get(url=url)
     response.raise_for_status()
     return response.json()[data_type]
-
-
-def get_years_from_dates(start_date: datetime, end_date: datetime) -> list:
-    """
-        Returns a list of unique years from a range of datetimes including both ends.
-    """
-    if start_date > end_date: 
-        raise ValueError(f"Invalid date range: start_date ({start_date}) must be <= end_date ({end_date})")
-
-    num_of_years = end_date.year - start_date.year + 1
-    return [start_date.year + i for i in range(num_of_years)]
 
 
 def build_url(base: str, path: str) -> str:

--- a/Section1-WeatherHolidaysPipeline/pipeline/transform.py
+++ b/Section1-WeatherHolidaysPipeline/pipeline/transform.py
@@ -1,4 +1,6 @@
-from datetime import datetime
+from datetime import datetime, time
+
+import pandas as pd
 
 
 def group_weather_info(weather_data: dict) -> list[dict]:
@@ -28,3 +30,22 @@ def get_years_from_dates(start_date: datetime, end_date: datetime) -> list:
 
     num_of_years = end_date.year - start_date.year + 1
     return [start_date.year + i for i in range(num_of_years)]
+
+
+def split_date_time_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """
+        Renames the original 'time' column to 'timestamp'
+        and creates 'date' and 'time' columns from 'timestamp'.
+    """
+    df = df.copy()
+    df = df.rename(columns={"time": "timestamp"})
+    df["timestamp"] = pd.to_datetime(df["timestamp"])
+    df["date"] = df["timestamp"].dt.date
+
+    # If all times are 00:00 set time to NaT
+    if (df["timestamp"].dt.time == time(0, 0)).all():
+        df["time"] = pd.NaT
+    else:
+        df["time"] = df["timestamp"].dt.time
+
+    return df

--- a/Section1-WeatherHolidaysPipeline/pipeline/transform.py
+++ b/Section1-WeatherHolidaysPipeline/pipeline/transform.py
@@ -49,3 +49,15 @@ def split_date_time_columns(df: pd.DataFrame) -> pd.DataFrame:
         df["time"] = df["timestamp"].dt.time
 
     return df
+
+
+def to_holiday_dates(dataframe: pd.DataFrame):
+    """
+        Return a DataFrame with only a 'date' column and a new 
+        'is_holiday' column set to True for all rows.
+    """
+    df = dataframe.copy()
+    df = df[["date"]]
+    df["is_holiday"] = True
+
+    return df

--- a/Section1-WeatherHolidaysPipeline/pipeline/transform.py
+++ b/Section1-WeatherHolidaysPipeline/pipeline/transform.py
@@ -61,3 +61,19 @@ def to_holiday_dates(dataframe: pd.DataFrame):
     df["is_holiday"] = True
 
     return df
+
+
+def cast_weather_data_types(dataframe: pd.DataFrame) -> pd.DataFrame:
+    df = dataframe.copy()
+
+    df["temperature_2m_mean"] = df["temperature_2m_mean"].astype("Float32")
+    df["temperature_2m_max"] = df["temperature_2m_max"].astype("Float32")
+    df["temperature_2m_min"] = df["temperature_2m_min"].astype("Float32")
+    df["precipitation_sum"] = df["precipitation_sum"].astype("Float32")
+
+    df["weather_code"] = df["weather_code"].astype("Float32").round().astype("Int32")
+
+    df["timestamp"] = pd.to_datetime(df["timestamp"])
+    df["date"] = pd.to_datetime(df["date"])
+
+    return df

--- a/Section1-WeatherHolidaysPipeline/pipeline/transform.py
+++ b/Section1-WeatherHolidaysPipeline/pipeline/transform.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+
+
+def group_weather_info(weather_data: dict) -> list[dict]:
+    """
+        Convert a dict of lists into a list of dicts, one per index.
+
+        All keys in the input dict must map to lists of the same length.
+    """
+    grouped_data = []
+    number_of_elements = len(weather_data["time"])
+
+    for i in range(number_of_elements):
+        data = {}
+        for key, value in weather_data.items():
+            data[key] = value[i]
+        grouped_data.append(data)
+
+    return grouped_data
+
+
+def get_years_from_dates(start_date: datetime, end_date: datetime) -> list:
+    """
+        Returns a list of unique years from a range of datetimes including both ends.
+    """
+    if start_date > end_date: 
+        raise ValueError(f"Invalid date range: start_date ({start_date}) must be <= end_date ({end_date})")
+
+    num_of_years = end_date.year - start_date.year + 1
+    return [start_date.year + i for i in range(num_of_years)]

--- a/Section1-WeatherHolidaysPipeline/tests/test_extract.py
+++ b/Section1-WeatherHolidaysPipeline/tests/test_extract.py
@@ -4,8 +4,7 @@ import pytest
 from urllib.parse import urlparse, parse_qs
 
 from pipeline.extract import (
-    get_city_info, build_weather_api_url, group_weather_info, get_start_date,
-    get_years_from_dates, build_url, get_holidays
+    get_city_info, build_weather_api_url, get_start_date, build_url, get_holidays
 )
 
 
@@ -40,38 +39,6 @@ def test_build_weather_api_url():
     assert parsed_params["hourly"][0] == "temperature_2m,relative_humidity_2m,soil_moisture_7_to_28cm"
 
 
-def test_group_weather_info():
-    test_dict = {
-        "time": ["2025-08-07", "2025-08-08", "2025-08-09"],
-        "temperature_2m_mean": [18.8, 20.8, 22.1],
-        "temperature_2m_max": [24.2, 26.9, 28.6],
-        "temperature_2m_min": [12.7, 15.5, 14.9]
-    }
-   
-    expected_result = [
-        {
-            "time": "2025-08-07",
-            "temperature_2m_mean": 18.8,
-            "temperature_2m_max": 24.2,
-            "temperature_2m_min": 12.7
-        },
-        {
-            "time": "2025-08-08",
-            "temperature_2m_mean": 20.8,
-            "temperature_2m_max": 26.9,
-            "temperature_2m_min": 15.5
-        },
-        {
-            "time": "2025-08-09",
-            "temperature_2m_mean": 22.1,
-            "temperature_2m_max": 28.6,
-            "temperature_2m_min": 14.9
-        },
-    ]
-
-    assert group_weather_info(test_dict) == expected_result
-
-
 def test_get_start_date_one_month():
     current_date = datetime(2025, 8, 23, 12, 0, 0)
     result = get_start_date(current_date, 1)
@@ -100,34 +67,6 @@ def test_get_start_date_large_offset():
     current_date = datetime(2025, 8, 23, 12, 0, 0)
     result = get_start_date(current_date, 24)
     assert result == datetime(2023, 8, 23, 12, 0, 0)
-
-
-def test_get_years_from_dates_five_years():
-    start_date = datetime(2020, 8, 12)
-    end_date = datetime(2025, 8, 12)
-
-    expected = [2020, 2021, 2022, 2023, 2024, 2025]
-    
-    assert get_years_from_dates(start_date=start_date, end_date=end_date) == expected
-
-
-def test_get_years_from_dates_same_year():
-    start_date = datetime(2023, 1, 1)
-    end_date = datetime(2023, 12, 31)
-    assert get_years_from_dates(start_date, end_date) == [2023]
-
-
-def test_get_years_from_dates_invalid_order():
-    start_date = datetime(2025, 1, 1)
-    end_date = datetime(2020, 1, 1)
-    with pytest.raises(ValueError):
-        get_years_from_dates(start_date, end_date)
-
-
-def test_get_years_from_dates_leap_year():
-    start_date = datetime(2019, 12, 31)
-    end_date = datetime(2020, 1, 1)
-    assert get_years_from_dates(start_date, end_date) == [2019, 2020]
 
 
 def test_build_url_no_trailing_leading_slashes():

--- a/Section1-WeatherHolidaysPipeline/tests/test_transform.py
+++ b/Section1-WeatherHolidaysPipeline/tests/test_transform.py
@@ -1,0 +1,65 @@
+from datetime import datetime
+
+import pytest
+
+from pipeline.transform import group_weather_info, get_years_from_dates
+
+
+def test_group_weather_info():
+    test_dict = {
+        "time": ["2025-08-07", "2025-08-08", "2025-08-09"],
+        "temperature_2m_mean": [18.8, 20.8, 22.1],
+        "temperature_2m_max": [24.2, 26.9, 28.6],
+        "temperature_2m_min": [12.7, 15.5, 14.9]
+    }
+   
+    expected_result = [
+        {
+            "time": "2025-08-07",
+            "temperature_2m_mean": 18.8,
+            "temperature_2m_max": 24.2,
+            "temperature_2m_min": 12.7
+        },
+        {
+            "time": "2025-08-08",
+            "temperature_2m_mean": 20.8,
+            "temperature_2m_max": 26.9,
+            "temperature_2m_min": 15.5
+        },
+        {
+            "time": "2025-08-09",
+            "temperature_2m_mean": 22.1,
+            "temperature_2m_max": 28.6,
+            "temperature_2m_min": 14.9
+        },
+    ]
+
+    assert group_weather_info(test_dict) == expected_result
+
+
+def test_get_years_from_dates_five_years():
+    start_date = datetime(2020, 8, 12)
+    end_date = datetime(2025, 8, 12)
+
+    expected = [2020, 2021, 2022, 2023, 2024, 2025]
+    
+    assert get_years_from_dates(start_date=start_date, end_date=end_date) == expected
+
+
+def test_get_years_from_dates_same_year():
+    start_date = datetime(2023, 1, 1)
+    end_date = datetime(2023, 12, 31)
+    assert get_years_from_dates(start_date, end_date) == [2023]
+
+
+def test_get_years_from_dates_invalid_order():
+    start_date = datetime(2025, 1, 1)
+    end_date = datetime(2020, 1, 1)
+    with pytest.raises(ValueError):
+        get_years_from_dates(start_date, end_date)
+
+
+def test_get_years_from_dates_leap_year():
+    start_date = datetime(2019, 12, 31)
+    end_date = datetime(2020, 1, 1)
+    assert get_years_from_dates(start_date, end_date) == [2019, 2020]

--- a/Section1-WeatherHolidaysPipeline/tests/test_transform.py
+++ b/Section1-WeatherHolidaysPipeline/tests/test_transform.py
@@ -5,7 +5,10 @@ import pandas as pd
 import pandas.testing as pdt
 from datetime import datetime, date, time
 
-from pipeline.transform import group_weather_info, get_years_from_dates, split_date_time_columns
+from pipeline.transform import (
+    group_weather_info, get_years_from_dates, split_date_time_columns,
+    to_holiday_dates
+)
 
 
 def test_group_weather_info():
@@ -104,3 +107,12 @@ def test_split_date_time_columns_dates_only():
     df_expected = pd.DataFrame(expected_data)
     
     pdt.assert_frame_equal(df_result, df_expected, check_like=True)
+
+
+def test_to_holiday_dates():
+    df = pd.DataFrame({"date": ["2025-01-01", "2025-01-02"], "value": [1, 2]})
+    result = to_holiday_dates(df)
+
+    assert list(result.columns) == ["date", "is_holiday"]
+    assert (result["is_holiday"] == True).all()
+    assert len(result) == len(df)


### PR DESCRIPTION
This PR moves existing helper functions from extract.py to transform.py and introduces new utilities for data transformation:

- Moved transformation helpers to transform.py for cleaner separation from extraction logic.
- Added split_date_time_columns: splits a datetime column into timestamp, date, and optionally time.
- Added normalize_weather_columns: normalizes weather data types, including numeric casting and datetime conversion.
- Updated build_weather_api_url: renamed data_type parameter to frequency for clarity.
- Corresponding pytest tests added for all helpers, including edge cases and daily/hourly data.

No extraction logic was modified; this is a refactor and enhancement of transformation utilities in preparation for merging weather and holiday data.